### PR TITLE
fix: sh cacheinfo not found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "pretty-bytes": "^6.0.0"
       },
       "bin": {
-        "cacheinfo": "dist/cli"
+        "cacheinfo": "dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^18.8.1",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
   "funding": "https://github.com/nickmccurdy/cacheinfo?sponsor=1",
   "main": "dist",
   "types": "dist",
-  "bin": {
-    "cacheinfo": "dist/cli.js"
-  },
+  "bin": "dist/cli.js",
   "repository": "nickmccurdy/cacheinfo",
   "scripts": {
     "prepare": "tsc"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "bin": "dist/cli.js",
   "repository": "nickmccurdy/cacheinfo",
   "scripts": {
-    "prepare": "tsc"
+    "prepare": "tsc && chmod +x dist/cli.js"
   },
   "dependencies": {
     "pretty-bytes": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "funding": "https://github.com/nickmccurdy/cacheinfo?sponsor=1",
   "main": "dist",
   "types": "dist",
-  "bin": "dist/cli",
+  "bin": {
+    "cacheinfo": "dist/cli.js"
+  },
   "repository": "nickmccurdy/cacheinfo",
   "scripts": {
     "prepare": "tsc"


### PR DESCRIPTION
This fixes https://github.com/nickmccurdy/cacheinfo/issues/4 for me locally. :eyes: 

I "tested" it via running `npm i -g` inside the root folder of the repo.